### PR TITLE
feat: make models index a system index

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -13,8 +13,6 @@ jobs:
           - 7.9.3
           - 7.8.1
           - 7.8.0
-          - 7.7.1
-          - 7.7.0
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,8 +53,6 @@ jobs:
           - 7.9.2
           - 7.8.1
           - 7.8.0
-          - 7.7.1
-          - 7.7.0
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK

--- a/src/main/java/io/zentity/common/FunctionalUtil.java
+++ b/src/main/java/io/zentity/common/FunctionalUtil.java
@@ -3,6 +3,7 @@ package io.zentity.common;
 import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.CheckedSupplier;
 
 import java.util.function.BiFunction;
@@ -137,6 +138,22 @@ public class FunctionalUtil {
 
         static <T, U, R, E extends Exception> UnCheckedBiFunction<T, U, R, E> from(CheckedBiFunction<T, U, R, E> f) {
             return f::apply;
+        }
+    }
+
+    @FunctionalInterface
+    public interface UnCheckedRunnable<E extends Exception> extends Runnable {
+        void runThrows() throws E;
+
+        default void run() {
+            sneakyWrap(() -> {
+                this.runThrows();
+                return null;
+            });
+        }
+
+        static <E extends Exception> UnCheckedRunnable<E> from(CheckedRunnable<E> runnable) {
+            return runnable::run;
         }
     }
 }

--- a/src/main/java/io/zentity/common/SecurityUtil.java
+++ b/src/main/java/io/zentity/common/SecurityUtil.java
@@ -1,7 +1,9 @@
 package io.zentity.common;
 
+import io.zentity.common.FunctionalUtil.UnCheckedRunnable;
 import io.zentity.common.FunctionalUtil.UnCheckedSupplier;
 import org.elasticsearch.SpecialPermission;
+import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.CheckedSupplier;
 
 import java.security.AccessController;
@@ -36,5 +38,26 @@ public class SecurityUtil {
      */
     public static <T> T doPrivileged(CheckedSupplier<T, ?> func) {
         return doPrivileged(UnCheckedSupplier.from(func));
+    }
+
+    /**
+     * Run something with escalated privileges.
+     *
+     * @param runnable The runnable to run.
+     */
+    public static void doPrivileged(Runnable runnable) {
+        doPrivileged((Supplier<Void>) () -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    /**
+     * Run something, that might throw a checked exception, with escalated privileges.
+     *
+     * @param runnable The runnable to run.
+     */
+    public static void doPrivileged(CheckedRunnable<?> runnable) {
+        doPrivileged(UnCheckedRunnable.from(runnable));
     }
 }

--- a/src/main/java/io/zentity/model/Attribute.java
+++ b/src/main/java/io/zentity/model/Attribute.java
@@ -6,8 +6,8 @@ import io.zentity.common.Json;
 import io.zentity.common.Patterns;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -16,7 +16,7 @@ import java.util.TreeSet;
 public class Attribute {
 
     public static final Set<String> VALID_TYPES = new TreeSet<>(
-            Arrays.asList("boolean", "date", "number", "string")
+        List.of("boolean", "date", "number", "string")
     );
 
     private final String name;

--- a/src/main/java/io/zentity/resolution/input/Term.java
+++ b/src/main/java/io/zentity/resolution/input/Term.java
@@ -14,6 +14,7 @@ import io.zentity.resolution.input.value.StringValue;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Objects;
 
 public class Term implements Comparable<Term> {
 
@@ -56,6 +57,7 @@ public class Term implements Comparable<Term> {
     }
 
     private void validateTerm(String term) throws ValidationException {
+        Objects.requireNonNull(term, "term cannot be null");
         if (Patterns.EMPTY_STRING.matcher(term).matches()) {
             throw new ValidationException("A term must be a non-empty string.");
         }
@@ -150,7 +152,7 @@ public class Term implements Comparable<Term> {
      */
     public StringValue stringValue() throws ValidationException {
         if (this.stringValue == null) {
-            this.stringValue = new StringValue(new TextNode(this.term));
+            this.stringValue = new StringValue(TextNode.valueOf(this.term));
         }
         return this.stringValue;
     }
@@ -166,7 +168,19 @@ public class Term implements Comparable<Term> {
     }
 
     @Override
-    public boolean equals(Object o) { return this.hashCode() == o.hashCode(); }
+    public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+
+        if (o.getClass() != this.getClass()) {
+            return false;
+        }
+
+        Term otherTerm = (Term) o;
+
+        return otherTerm.term.equals(term);
+    }
 
     @Override
     public int hashCode() { return this.term.hashCode(); }

--- a/src/main/java/io/zentity/resolution/input/value/Value.java
+++ b/src/main/java/io/zentity/resolution/input/value/Value.java
@@ -3,6 +3,8 @@ package io.zentity.resolution.input.value;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.zentity.model.ValidationException;
 
+import java.util.Objects;
+
 public abstract class Value implements ValueInterface {
 
     protected final String type = "value";
@@ -15,6 +17,7 @@ public abstract class Value implements ValueInterface {
      * @param value Attribute value.
      */
     Value(JsonNode value) throws ValidationException {
+        Objects.requireNonNull(value, "Value node cannot be null");
         this.validate(value);
         this.value = value;
     }
@@ -78,9 +81,22 @@ public abstract class Value implements ValueInterface {
     }
 
     @Override
-    public boolean equals(Object o) { return this.hashCode() == o.hashCode(); }
+    public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+
+        if (o.getClass() != this.getClass()) {
+            return false;
+        }
+
+        Value otherVal = (Value) o;
+
+        return serialized().equals(otherVal.serialized());
+    }
 
     @Override
-    public int hashCode() { return this.serialized().hashCode(); }
-
+    public int hashCode() {
+        return this.serialized().hashCode();
+    }
 }

--- a/src/main/java/org/elasticsearch/plugin/zentity/HomeAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/HomeAction.java
@@ -45,12 +45,9 @@ public class HomeAction extends BaseZentityAction {
 
         final boolean pretty = restRequest.paramAsBoolean("pretty", false);
 
-        final UnaryOperator<XContentBuilder> prettyPrintModifier = (builder) -> {
-            if (pretty) {
-                return builder.prettyPrint();
-            }
-            return builder;
-        };
+        final UnaryOperator<XContentBuilder> prettyPrintModifier = pretty
+            ? XContentBuilder::prettyPrint
+            : UnaryOperator.identity();
 
         final UnaryOperator<XContentBuilder> propsResponseModifier = UnCheckedUnaryOperator.from((builder) -> {
             builder.startObject();

--- a/src/main/java/org/elasticsearch/plugin/zentity/ModelsAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ModelsAction.java
@@ -187,7 +187,14 @@ public class ModelsAction extends BaseZentityAction {
     }
 
     @Override
+    public boolean allowSystemIndexAccessByDefault() {
+        return true;
+    }
+
+    @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        // Allow access the model system index
+        client.threadPool().getThreadContext().markAsSystemContext();
 
         // Parse request
         String entityType = restRequest.param("entity_type");

--- a/src/main/java/org/elasticsearch/plugin/zentity/ModelsAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ModelsAction.java
@@ -45,8 +45,6 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
 public class ModelsAction extends BaseZentityAction {
 
-    public static final String INDEX_NAME = ".zentity-models";
-
     public ModelsAction(ZentityConfig config) {
         super(config);
     }
@@ -202,12 +200,9 @@ public class ModelsAction extends BaseZentityAction {
         Method method = restRequest.method();
         String requestBody = restRequest.content().utf8ToString();
 
-        final UnaryOperator<XContentBuilder> prettyPrintModifier = (builder) -> {
-            if (pretty) {
-                return builder.prettyPrint();
-            }
-            return builder;
-        };
+        final UnaryOperator<XContentBuilder> prettyPrintModifier = pretty
+            ? XContentBuilder::prettyPrint
+            : UnaryOperator.identity();
 
         return errorHandlingConsumer(channel -> {
             // Validate input

--- a/src/main/java/org/elasticsearch/plugin/zentity/ResolutionAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ResolutionAction.java
@@ -262,6 +262,11 @@ public class ResolutionAction extends BaseZentityAction {
     }
 
     @Override
+    public boolean allowSystemIndexAccessByDefault() {
+        return true;
+    }
+
+    @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
         if (!restRequest.hasContent()) {
             // Validate the request body.

--- a/src/main/java/org/elasticsearch/plugin/zentity/ResolutionAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ResolutionAction.java
@@ -236,8 +236,8 @@ public class ResolutionAction extends BaseZentityAction {
         return buildAndRunJobAsync(client, body, reqParams, emptyMap())
             .thenApply(UnCheckedFunction.from((res) -> {
                 // Jackson needs reflection access, which requires escalated security
-                String responseJson = SecurityUtil.doPrivileged((
-                    CheckedSupplier<String, ?>) () -> responseWriter.writeValueAsString(res)
+                String responseJson = SecurityUtil.doPrivileged(
+                    (CheckedSupplier<String, ?>) () -> responseWriter.writeValueAsString(res)
                 );
 
                 RestStatus status = res.isFailure() ? RestStatus.INTERNAL_SERVER_ERROR : RestStatus.OK;

--- a/src/main/java/org/elasticsearch/plugin/zentity/ZentityConfig.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ZentityConfig.java
@@ -7,7 +7,6 @@ import org.elasticsearch.env.Environment;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 public class ZentityConfig {
@@ -69,7 +68,7 @@ public class ZentityConfig {
     }
 
     public List<Setting<?>> getSettings() {
-        return Arrays.asList(
+        return List.of(
             RESOLUTION_MAX_CONCURRENT_JOBS,
             RESOLUTION_MAX_CONCURRENT_JOBS_PER_REQUEST,
             MODELS_INDEX_NAME,

--- a/src/main/java/org/elasticsearch/plugin/zentity/ZentityPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ZentityPlugin.java
@@ -25,8 +25,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.rest.RestStatus;
@@ -47,7 +48,7 @@ import java.util.Properties;
 import java.util.TreeMap;
 import java.util.function.Supplier;
 
-public class ZentityPlugin extends Plugin implements ActionPlugin {
+public class ZentityPlugin extends Plugin implements SystemIndexPlugin {
 
     private static final Properties PROPERTIES = new Properties();
 
@@ -188,5 +189,19 @@ public class ZentityPlugin extends Plugin implements ActionPlugin {
     @Override
     public List<Setting<?>> getSettings() {
         return config.getSettings();
+    }
+
+    /**
+     * Returns a {@link Collection} of {@link SystemIndexDescriptor}s that describe this plugin's system indices, including
+     * name, mapping, and settings.
+     *
+     * @param settings The node's settings.
+     * @return Descriptions of the system indices managed by this plugin.
+     */
+    @Override
+    public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+        return List.of(
+            new SystemIndexDescriptor(config.getModelsIndexName(), "The main index for storing Zentity Models")
+        );
     }
 }

--- a/src/main/java/org/elasticsearch/plugin/zentity/ZentityPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ZentityPlugin.java
@@ -17,7 +17,7 @@ import org.elasticsearch.action.search.SearchResponseSections;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.common.CheckedSupplier;
+import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -66,7 +66,7 @@ public class ZentityPlugin extends Plugin implements SystemIndexPlugin {
 
         // Initializing Jackson requires reflection permissions
         // see: https://github.com/elastic/elasticsearch/blob/fc5725597189a4ee36b265a8fb75fa616b63e41b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java#L60-L74
-        SecurityUtil.doPrivileged((CheckedSupplier<?, ?>) () -> {
+        SecurityUtil.doPrivileged((CheckedRunnable<?>) () -> {
             // kick jackson to do some static caching of declared members info
             // Maybe move this to another place, but it is very hacky so maybe ok to leave here?
             Json.MAPPER.readTree("{}");
@@ -143,7 +143,6 @@ public class ZentityPlugin extends Plugin implements SystemIndexPlugin {
                 Json.MAPPER.writeValueAsString(obj);
                 Json.ORDERED_MAPPER.writeValueAsString(obj);
             }));
-            return null;
         });
     }
 

--- a/src/test/java/org/elasticsearch/plugin/zentity/SetupActionIT.java
+++ b/src/test/java/org/elasticsearch/plugin/zentity/SetupActionIT.java
@@ -1,0 +1,53 @@
+package org.elasticsearch.plugin.zentity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.zentity.common.Json;
+import io.zentity.devtools.AbstractITCase;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SetupActionIT extends AbstractITCase {
+    @Test
+    public void testSetup() throws Exception {
+        Response response = client.performRequest(new Request("POST", "_zentity/_setup"));
+        JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
+
+        assertTrue("should be acknowledged", json.has("acknowledged") && json.get("acknowledged").asBoolean());
+
+        try {
+            Response getIndexRes = client.performRequest(new Request("GET", ".zentity-models"));
+            JsonNode getResJson = Json.MAPPER.readTree(getIndexRes.getEntity().getContent());
+
+            assertTrue("found index", getResJson.has(".zentity-models"));
+
+            JsonNode indexSettings = getResJson.at("/.zentity-models/settings/index");
+            assertEquals("default # of shards", 1, indexSettings.get("number_of_shards").asInt());
+            assertEquals("default # of replicas", 1, indexSettings.get("number_of_replicas").asInt());
+        } finally {
+            client.performRequest(new Request("DELETE", ".zentity-models"));
+        }
+    }
+
+    @Test
+    public void testUninstall() throws Exception {
+        client.performRequest(new Request("POST", "_zentity/_setup"));
+
+        Response response = client.performRequest(new Request("DELETE", "_zentity/_setup"));
+        JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
+
+        assertTrue("should be acknowledged", json.has("acknowledged") && json.get("acknowledged").asBoolean());
+
+        try {
+            client.performRequest(new Request("GET", ".zentity-models"));
+            fail("expected failure");
+        } catch (ResponseException ex) {
+            assertEquals("index not found", 404, ex.getResponse().getStatusLine().getStatusCode());
+        }
+    }
+}


### PR DESCRIPTION
BREAKING CHANGE:
In ES 8.0, creating indices that start with a `.` will be deprecated unless they are either hidden or system indices. This PR makes the `.zentity-models` index a system index. From the ES documentation, a system index is:
> An index that contains configuration information or other data used internally by the system, such as the .security index. The name of a system index is always prefixed with a dot. You should not directly access or modify system indices. 


More can be found about the change here: https://github.com/elastic/elasticsearch/issues/50251 

Should not be merged until min. supported version is >= 7.10